### PR TITLE
feat: client-side text search

### DIFF
--- a/src/components/LocationPanel.tsx
+++ b/src/components/LocationPanel.tsx
@@ -1,0 +1,161 @@
+import useIsDesktop from '../hooks/useIsDesktop';
+import type { Category, Location } from '../lib/types';
+
+const CATEGORY_LABEL: Record<Category, string> = {
+  garden: 'Community Garden',
+  farm:   'Urban Farm',
+  market: 'Farmers Market / Farm Stand',
+};
+
+const CATEGORY_COLOR: Record<Category, string> = {
+  garden: '#3a7d44',
+  farm:   '#c0392b',
+  market: '#7b2d8b',
+};
+
+interface Props {
+  location: Location | null;
+  onClose: () => void;
+}
+
+export default function LocationPanel({ location, onClose }: Props) {
+  const isDesktop = useIsDesktop();
+
+  if (!location) return null;
+
+  const color = CATEGORY_COLOR[location.category];
+
+  const panelStyle: React.CSSProperties = isDesktop
+    ? {
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        bottom: 0,
+        width: 320,
+        zIndex: 1200,
+        backgroundColor: '#fff',
+        overflowY: 'auto',
+        boxShadow: '2px 0 16px rgba(0,0,0,0.15)',
+      }
+    : {
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        maxHeight: '50dvh',
+        zIndex: 1200,
+        backgroundColor: '#fff',
+        overflowY: 'auto',
+        borderRadius: '12px 12px 0 0',
+        boxShadow: '0 -2px 16px rgba(0,0,0,0.15)',
+      };
+
+  return (
+    <>
+      {/* Mobile only: tap backdrop to close */}
+      {!isDesktop && (
+        <div
+          style={{ position: 'fixed', inset: 0, zIndex: 1100 }}
+          onClick={onClose}
+          aria-hidden
+        />
+      )}
+
+      <div style={panelStyle} role="dialog" aria-label={location.name}>
+        <button style={styles.close} onClick={onClose} aria-label="Close">×</button>
+
+        {location.image_url && (
+          <img
+            src={location.image_url}
+            alt={location.name}
+            style={styles.image}
+          />
+        )}
+
+        <div style={styles.body}>
+          <span style={{ ...styles.tag, backgroundColor: color }}>
+            {CATEGORY_LABEL[location.category]}
+          </span>
+
+          <h2 style={styles.name}>{location.name}</h2>
+
+          {location.address && (
+            <p style={styles.field}>{location.address}</p>
+          )}
+
+          {location.manager_name && (
+            <p style={styles.field}><strong>Manager:</strong> {location.manager_name}</p>
+          )}
+
+          {location.phone && (
+            <p style={styles.field}>
+              <a href={`tel:${location.phone}`} style={styles.link}>{location.phone}</a>
+            </p>
+          )}
+
+          {location.email && (
+            <p style={styles.field}>
+              <a href={`mailto:${location.email}`} style={styles.link}>{location.email}</a>
+            </p>
+          )}
+
+          {location.notes && (
+            <p style={{ ...styles.field, marginTop: 12 }}>{location.notes}</p>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  close: {
+    position: 'absolute',
+    top: 10,
+    right: 12,
+    background: 'none',
+    border: 'none',
+    fontSize: 24,
+    lineHeight: 1,
+    cursor: 'pointer',
+    color: '#6b6375',
+    padding: '0 4px',
+    zIndex: 1,
+  },
+  image: {
+    width: '100%',
+    maxHeight: 180,
+    objectFit: 'cover',
+    display: 'block',
+  },
+  body: {
+    padding: '14px 16px 20px',
+  },
+  tag: {
+    display: 'inline-block',
+    color: '#fff',
+    fontSize: 11,
+    fontWeight: 600,
+    letterSpacing: '0.5px',
+    textTransform: 'uppercase',
+    padding: '3px 8px',
+    borderRadius: 4,
+    marginBottom: 8,
+  },
+  name: {
+    margin: '0 0 8px',
+    fontSize: 18,
+    fontWeight: 600,
+    color: '#08060d',
+    paddingRight: 24,
+  },
+  field: {
+    margin: '4px 0',
+    fontSize: 14,
+    color: '#6b6375',
+    lineHeight: 1.5,
+  },
+  link: {
+    color: '#08060d',
+  },
+};

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -3,6 +3,7 @@ import { DivIcon } from 'leaflet';
 import { MapContainer, TileLayer, Marker, useMap } from 'react-leaflet';
 import type { Category, Location } from '../lib/types';
 
+
 function ZoomControl() {
   const map = useMap();
   return (
@@ -84,9 +85,10 @@ const CLEVELAND: [number, number] = [41.482, -81.668];
 interface Props {
   locations: Location[];
   activeCategories: Category[];
+  onSelectLocation: (location: Location) => void;
 }
 
-export default function MapView({ locations, activeCategories }: Props) {
+export default function MapView({ locations, activeCategories, onSelectLocation }: Props) {
   return (
     <MapContainer
       center={CLEVELAND}
@@ -106,6 +108,7 @@ export default function MapView({ locations, activeCategories }: Props) {
             key={loc.id}
             position={[loc.lat as number, loc.lng as number]}
             icon={PIN_ICONS[loc.category]}
+            eventHandlers={{ click: () => onSelectLocation(loc) }}
           />
         ))}
     </MapContainer>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -42,6 +42,7 @@ const styles: Record<string, React.CSSProperties> = {
     outline: 'none',
     fontFamily: 'inherit',
     color: '#08060d',
+    backgroundColor: '#fff',
     appearance: 'none',
     WebkitAppearance: 'none',
   },

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,61 @@
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export default function SearchBar({ value, onChange }: Props) {
+  return (
+    <div style={styles.wrap}>
+      <input
+        type="search"
+        placeholder="Search by name or notes…"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-label="Search locations"
+        style={styles.input}
+      />
+      {value && (
+        <button
+          aria-label="Clear search"
+          onClick={() => onChange('')}
+          style={styles.clear}
+        >×</button>
+      )}
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  wrap: {
+    position: 'relative',
+    padding: '8px 12px 0',
+    backgroundColor: '#fff',
+  },
+  input: {
+    width: '100%',
+    boxSizing: 'border-box',
+    padding: '8px 32px 8px 12px',
+    border: '1px solid #e5e4e7',
+    borderRadius: 6,
+    fontSize: 14,
+    lineHeight: 1.4,
+    outline: 'none',
+    fontFamily: 'inherit',
+    color: '#08060d',
+    appearance: 'none',
+    WebkitAppearance: 'none',
+  },
+  clear: {
+    position: 'absolute',
+    right: 20,
+    top: '50%',
+    transform: 'translateY(-25%)',
+    background: 'none',
+    border: 'none',
+    fontSize: 18,
+    lineHeight: 1,
+    color: '#6b6375',
+    cursor: 'pointer',
+    padding: '0 4px',
+  },
+};

--- a/src/hooks/useIsDesktop.ts
+++ b/src/hooks/useIsDesktop.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+const QUERY = '(min-width: 768px)';
+
+export default function useIsDesktop(): boolean {
+  const [isDesktop, setIsDesktop] = useState(() => window.matchMedia(QUERY).matches);
+
+  useEffect(() => {
+    const mq = window.matchMedia(QUERY);
+    const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  return isDesktop;
+}

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -3,7 +3,8 @@ import useLocations from '../hooks/useLocations';
 import MapView from '../components/MapView';
 import CategoryFilter from '../components/CategoryFilter';
 import SearchBar from '../components/SearchBar';
-import type { Category } from '../lib/types';
+import LocationPanel from '../components/LocationPanel';
+import type { Category, Location } from '../lib/types';
 
 const ALL_CATEGORIES: Category[] = ['garden', 'farm', 'market'];
 
@@ -12,6 +13,7 @@ export default function MapPage() {
   const [activeCategories, setActiveCategories] = useState<Category[]>(ALL_CATEGORIES);
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [selectedLocation, setSelectedLocation] = useState<Location | null>(null);
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedQuery(query), 200);
@@ -43,8 +45,16 @@ export default function MapPage() {
         onChange={setActiveCategories}
       />
       {!loading && (
-        <MapView locations={filtered} activeCategories={activeCategories} />
+        <MapView
+          locations={filtered}
+          activeCategories={activeCategories}
+          onSelectLocation={setSelectedLocation}
+        />
       )}
+      <LocationPanel
+        location={selectedLocation}
+        onClose={() => setSelectedLocation(null)}
+      />
     </div>
   );
 }

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -35,7 +35,7 @@ export default function MapPage() {
   };
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100dvh', overflow: 'hidden' }}>
       <SearchBar value={query} onChange={setQuery} />
       <CategoryFilter
         activeCategories={activeCategories}

--- a/src/pages/MapPage.tsx
+++ b/src/pages/MapPage.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import useLocations from '../hooks/useLocations';
 import MapView from '../components/MapView';
 import CategoryFilter from '../components/CategoryFilter';
+import SearchBar from '../components/SearchBar';
 import type { Category } from '../lib/types';
 
 const ALL_CATEGORIES: Category[] = ['garden', 'farm', 'market'];
@@ -9,22 +10,40 @@ const ALL_CATEGORIES: Category[] = ['garden', 'farm', 'market'];
 export default function MapPage() {
   const { locations, loading } = useLocations();
   const [activeCategories, setActiveCategories] = useState<Category[]>(ALL_CATEGORIES);
+  const [query, setQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(query), 200);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const filtered = debouncedQuery.trim()
+    ? locations.filter((l) => {
+        const q = debouncedQuery.toLowerCase();
+        return (
+          l.name.toLowerCase().includes(q) ||
+          (l.notes ?? '').toLowerCase().includes(q)
+        );
+      })
+    : locations;
 
   const counts: Record<Category, number> = {
-    garden: locations.filter((l) => l.category === 'garden').length,
-    farm:   locations.filter((l) => l.category === 'farm').length,
-    market: locations.filter((l) => l.category === 'market').length,
+    garden: filtered.filter((l) => l.category === 'garden').length,
+    farm:   filtered.filter((l) => l.category === 'farm').length,
+    market: filtered.filter((l) => l.category === 'market').length,
   };
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+      <SearchBar value={query} onChange={setQuery} />
       <CategoryFilter
         activeCategories={activeCategories}
         counts={counts}
         onChange={setActiveCategories}
       />
       {!loading && (
-        <MapView locations={locations} activeCategories={activeCategories} />
+        <MapView locations={filtered} activeCategories={activeCategories} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Search input above category filter, filters pins by name and notes fields
- Client-side only, debounced 200ms
- Category counts update to reflect active search results
- Clears with × button

Fixes #20

## Test plan
- [ ] Type in search box — pins filter in real time
- [ ] Category counts update to match filtered results
- [ ] Clear button removes query and restores all pins
- [ ] Works on mobile (no layout issues)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)