### PR TITLE
fix: accessibility pass on public map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,19 +168,37 @@ VITE_SUPABASE_ANON_KEY=
 - [x] KML import script at `scripts/import-kml.ts` — run with `npm run import-kml`
 - [x] 105 records imported from KML
 
+### Phase 3 — Public Map UI
+- [x] `src/lib/supabase.ts` — typed Supabase client
+- [x] `src/lib/types.ts` — shared TypeScript types from DB schema
+- [x] `src/pages/MapPage.tsx` — public map with react-leaflet
+- [x] Category-colored pins (green/red/purple per design rules)
+- [x] Click-to-open location detail panel (mobile sheet, desktop sidebar overlay)
+- [x] Filter by category with counts
+- [x] Client-side text search (name + notes, debounced 200ms)
+- [x] Locations with null lat/lng excluded from map, no error thrown
+- [x] Accessibility pass — ARIA labels, keyboard nav, focus management, WCAG AA contrast
+- [x] Mobile zoom buttons fixed (custom `<button>` control, no `<a href="#">`)
+- [x] Mobile keyboard/viewport fix (`100dvh`)
+- [ ] Custom pin icons — #50 (deferred, needs design reference)
+- [ ] Collapsible search/filter strip — #45 (deferred)
+- [ ] Desktop sidebar pushes map — #48 (deferred)
+
 ---
 
 ## Current Phase
 
-**Phase 3 — Public Map UI**
+**Phase 4 — Admin UI**
 
-- [ ] `src/lib/supabase.ts` — typed Supabase client
-- [ ] `src/lib/types.ts` — shared TypeScript types from DB schema
-- [ ] `src/pages/MapPage.tsx` — public map with react-leaflet
-- [ ] Category-colored pins (green/red/purple per design rules)
-- [ ] Click-to-open location detail panel (mobile sheet, desktop sidebar)
-- [ ] Filter by category
-- [ ] Locations with null lat/lng excluded from map, no error thrown
+- [ ] Auth flow — login page with magic link + Google OAuth + GitHub OAuth (#26)
+- [ ] Protected route — redirect unauthenticated to /login (#27)
+- [ ] Admin location list view (#28)
+- [ ] Add location form (#29)
+- [ ] Edit location form (#30)
+- [ ] Archive / restore location (#31)
+- [ ] Image upload — Supabase Storage (#32)
+- [ ] Form validation — client and Supabase (#33)
+- [ ] Mobile-first admin layout (#34)
 
 ---
 

--- a/src/components/CategoryFilter.tsx
+++ b/src/components/CategoryFilter.tsx
@@ -40,7 +40,7 @@ export default function CategoryFilter({ activeCategories, counts, onChange }: P
           <button
             key={cat}
             onClick={() => toggle(cat)}
-            disabled={isLast}
+            aria-disabled={isLast}
             aria-pressed={active}
             style={{
               ...styles.btn,

--- a/src/components/LocationPanel.tsx
+++ b/src/components/LocationPanel.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import useIsDesktop from '../hooks/useIsDesktop';
 import type { Category, Location } from '../lib/types';
 
@@ -20,6 +21,25 @@ interface Props {
 
 export default function LocationPanel({ location, onClose }: Props) {
   const isDesktop = useIsDesktop();
+  const closeRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<Element | null>(null);
+
+  useEffect(() => {
+    if (location) {
+      previousFocusRef.current = document.activeElement;
+      closeRef.current?.focus();
+    } else if (previousFocusRef.current instanceof HTMLElement) {
+      previousFocusRef.current.focus();
+    }
+  }, [location]);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape' && location) onClose();
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [location, onClose]);
 
   if (!location) return null;
 
@@ -61,8 +81,8 @@ export default function LocationPanel({ location, onClose }: Props) {
         />
       )}
 
-      <div style={panelStyle} role="dialog" aria-label={location.name}>
-        <button style={styles.close} onClick={onClose} aria-label="Close">×</button>
+      <div style={panelStyle} role="dialog" aria-modal="true" aria-label={location.name}>
+        <button ref={closeRef} style={styles.close} onClick={onClose} aria-label="Close">×</button>
 
         {location.image_url && (
           <img

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -57,11 +57,18 @@ const CATEGORY_COLOR: Record<Category, string> = {
   market: '#7b2d8b',
 };
 
+const CATEGORY_LABEL: Record<Category, string> = {
+  garden: 'Community Garden',
+  farm:   'Urban Farm',
+  market: 'Farmers Market / Farm Stand',
+};
+
 function makePinIcon(category: Category): DivIcon {
   const color = CATEGORY_COLOR[category];
+  const label = CATEGORY_LABEL[category];
   // Teardrop: circle body tapering to a downward point
   const svg =
-    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 32" width="24" height="32">` +
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 32" width="24" height="32" role="img" aria-label="${label}">` +
     `<path d="M12 0C7.58 0 4 3.58 4 8c0 5.25 8 16 8 16s8-10.75 8-16c0-4.42-3.58-8-8-8z"` +
     ` fill="${color}" stroke="rgba(0,0,0,0.25)" stroke-width="1"/>` +
     `</svg>`;
@@ -95,6 +102,7 @@ export default function MapView({ locations, activeCategories, onSelectLocation 
       zoom={12}
       zoomControl={false}
       style={{ height: 'calc(100vh - 56px)', width: '100%' }}
+      aria-label="Map of Cleveland food resources"
     >
       <ZoomControl />
       <TileLayer
@@ -108,6 +116,8 @@ export default function MapView({ locations, activeCategories, onSelectLocation 
             key={loc.id}
             position={[loc.lat as number, loc.lng as number]}
             icon={PIN_ICONS[loc.category]}
+            title={loc.name}
+            alt={`${CATEGORY_LABEL[loc.category]}: ${loc.name}`}
             eventHandlers={{ click: () => onSelectLocation(loc) }}
           />
         ))}


### PR DESCRIPTION
## Summary
- `aria-disabled` instead of `disabled` on last-active filter button (keeps it in tab order)
- Markers get `title` + `alt` props; pin SVGs get `role="img"` with category label
- `MapContainer` gets `aria-label`
- `LocationPanel` gets `aria-modal="true"`, Escape to close, focus moves to × on open and returns on close

All text/UI colors confirmed WCAG AA compliant.

Fixes #25

## Test plan
- [ ] Tab through filter buttons — all three reachable including the last active one
- [ ] Hover a pin — tooltip shows location name
- [ ] Open panel, press Escape — closes and focus returns
- [ ] Open panel, tab to ×, press Enter — closes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)